### PR TITLE
Update Kitsu Batoto Links

### DIFF
--- a/kitsu-batoto.user.js
+++ b/kitsu-batoto.user.js
@@ -50,17 +50,17 @@
 				Util.log('Loading cached info');
 				cb(self.cache[title]);
 			} else {
-				var url = 'https://www.google.com/search?q=' + encodeURIComponent(title.trim() + ' site:bato.to/comic/_/comics');
-				Util.log('Searching Google for Batoto page:', url);
+				var url = 'https://duckduckgo.com/html/?q=' + encodeURIComponent(title.trim() + ' site:bato.to/comic/_/comics');
+				Util.log('Searching DuckDuckGo for Batoto page:', url);
 				GM_xmlhttpRequest({
 					method: 'GET',
 					url: url,
 					onload: function(response) {
-						Util.log('Loaded Google search');
+						Util.log('Loaded DuckDuckGo search');
 						var tempDiv = document.createElement('div');
 						tempDiv.innerHTML = response.responseText;
 
-						var manga = Util.q('#rso > div > div:nth-child(1) h3 > a', tempDiv);
+						var manga = Util.q('#links > div:first-child .result__extras__url > a.result__url', tempDiv);
 						if (manga) {
 							manga.href = manga.href.replace('http://', 'https://');
 							Util.log('Batoto link:', manga.href);
@@ -73,7 +73,7 @@
 						}
 					},
 					onerror: function() {
-						Util.log('Error searching Google');
+						Util.log('Error searching DuckDuckGo');
 					}
 				});
 			}

--- a/kitsu-batoto.user.js
+++ b/kitsu-batoto.user.js
@@ -1,11 +1,11 @@
 // ==UserScript==
 // @name         Kitsu Batoto Links
 // @namespace    https://greasyfork.org/users/649
-// @version      2.0.1
+// @version      2.0.2
 // @description  Adds Batoto links to Kitsu manga pages
 // @author       Adrien Pyke
 // @match        *://kitsu.io/*
-// @require      https://greasyfork.org/scripts/5679-wait-for-elements/code/Wait%20For%20Elements.js?version=122976
+// @require      https://greasyfork.org/scripts/5679-wait-for-elements/code/Wait%20For%20Elements.js?version=147465
 // @grant        GM_xmlhttpRequest
 // ==/UserScript==
 
@@ -81,29 +81,32 @@
 	};
 
 	waitForUrl(MANGA_REGEX, function() {
-		waitForElems('.media-cover-wrapper .cover-username', function(title) {
-			var followGroup = Util.q('.media-cover-wrapper .cover-cta');
-			var linkCheck = Util.q('a', followGroup);
-			if (linkCheck) {
-				followGroup.removeChild(linkCheck);
-			}
-
-			var url = location.href;
-			App.getBatotoPage(Util.shallowTextContent(title), function(manga) {
-				if (location.href === url && manga) {
-					var linkElem = document.createElement('a');
-					linkElem.setAttribute('style', 'display: inline-block;');
-					linkElem.setAttribute('target', '_blank');
-					linkElem.href = manga;
-					followGroup.appendChild(linkElem);
-					var btnElem = document.createElement('button');
-					btnElem.classList.add('button');
-					btnElem.classList.add('button--primary');
-					btnElem.textContent = "Batoto";
-					btnElem.setAttribute('style', 'margin-top: 0.5px;');
-					linkElem.appendChild(btnElem);
+		waitForElems({
+			sel: '.media-cover-wrapper .cover-username',
+			stop: true,
+			onmatch: function(title) {
+				var followGroup = Util.q('.media-cover-wrapper .cover-cta');
+				var linkCheck = Util.q('a', followGroup);
+				if (linkCheck) {
+					followGroup.removeChild(linkCheck);
 				}
-			});
-		}, true);
+				var url = location.href;
+				App.getBatotoPage(Util.shallowTextContent(title), function(manga) {
+					if (location.href === url && manga) {
+						var linkElem = document.createElement('a');
+						linkElem.setAttribute('style', 'display: inline-block;');
+						linkElem.setAttribute('target', '_blank');
+						linkElem.href = manga;
+						followGroup.appendChild(linkElem);
+						var btnElem = document.createElement('button');
+						btnElem.classList.add('button');
+						btnElem.classList.add('button--primary');
+						btnElem.textContent = "Batoto";
+						btnElem.setAttribute('style', 'margin-top: 0.5px;');
+						linkElem.appendChild(btnElem);
+					}
+				});
+			}
+		});
 	});
 })();


### PR DESCRIPTION
Updated the wait for elements version and switched to DuckDuckGo's search engine for more accurate results.

Some examples:
- Dagashi Kashi
  - [Google](https://www.google.com/#newwindow=1&safe=off&q=Dagashi+Kashi+site:bato.to%2Fcomic%2F_%2Fcomics) - link removed due to DMCA
  - [DDG](https://duckduckgo.com/html/?q=Dagashi%20Kashi%20site%3Abato.to%2Fcomic%2F_%2Fcomics)
- Sidonia no Kishi
  - [Google](https://www.google.com/#newwindow=1&safe=off&q=Sidonia+no+Kishi+site:bato.to%2Fcomic%2F_%2Fcomics) - shows a doujin as the first result
  - [DDG](https://duckduckgo.com/html/?q=Sidonia%20no%20Kishi%20site%3Abato.to%2Fcomic%2F_%2Fcomics)
- Oyasumi Punpun
  - [Google](https://www.google.com/#newwindow=1&safe=off&q=Oyasumi+Punpun+site:bato.to%2Fcomic%2F_%2Fcomics) - link removed due to DMCA
  - [DDG](https://duckduckgo.com/html/?q=Oyasumi%20Punpun%20site%3Abato.to%2Fcomic%2F_%2Fcomics)