### PR TITLE
new setting: requireShift

### DIFF
--- a/youtube-volume.user.js
+++ b/youtube-volume.user.js
@@ -26,7 +26,8 @@
 	const Config = GM_config([
 		{ key: 'reverse', label: 'Reverse Scroll', default: false, type: 'bool' },
 		{ key: 'step', label: 'Change By', default: 5, type: 'number', min: 1, max: 100 },
-		{ key: 'hud', label: 'Display HUD', default: true, type: 'bool' }
+		{ key: 'hud', label: 'Display HUD', default: true, type: 'bool' },
+		{ key: 'requireShift', label: 'Only handle scroll if holding "Shift" key', default: false, type: 'bool' }
 	]);
 	GM_registerMenuCommand('Youtube Scroll Volume Settings', Config.setup);
 
@@ -85,6 +86,7 @@
 			};
 
 			node.onwheel = e => {
+				if(config.requireShift && !e.shiftKey) return;
 				const player = node.getPlayer();
 				const dir = (e.deltaY > 0 ? -1 : 1) * (config.reverse ? -1 : 1);
 


### PR DESCRIPTION
if setting is enabled only scroll if shiftKey is held down

I'm on a roll baby, feel free to reject, but I'd personally have this enabled. Otherwise it's annoying when scrolling down for comments.